### PR TITLE
Revert "handling -1 as NA value"

### DIFF
--- a/src/main/java/org/geppetto/model/swc/format/SWCReader.java
+++ b/src/main/java/org/geppetto/model/swc/format/SWCReader.java
@@ -93,7 +93,7 @@ public class SWCReader
 					for(int j = 0; j < 7; j++)
 					{
 						String nextToken = st.nextToken();
-						if(nextToken.equals("NA") || nextToken.equals("-1"))
+						if(nextToken.equals("NA"))
 						{
 							nextToken = "1";
 						}


### PR DESCRIPTION
Reverts openworm/org.geppetto.model.swc#8

In hindsight it's better to fix this in the files as is also changing -1 in the other columns causing soma parent to fail.